### PR TITLE
Add Service URL presets with pin/unpin support in GeoMapFish plugin

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -55,7 +55,7 @@ Item {
     prefix: "gmf"
     locatorBridge: iface.findItemByObjectName('locatorBridge')
     parameters: {
-      "service_custom_url": settings.service_custom_url || plugin.getActivePreset().url,
+      "service_url": settings.service_custom_url || plugin.getActivePreset().url,
       "service_crs": settings.service_crs || plugin.getActivePreset().crs
     }
     source: Qt.resolvedUrl('geomapfish.qml')
@@ -143,21 +143,18 @@ Item {
 
     function updateUI() {
       const isCustom = endpointCombo.currentText === qsTr("Custom");
-
       customUrlRow.visible = isCustom;
-
-      if (isCustom) {
-        Qt.callLater(() => {
-          customUrlCombo.forceActiveFocus();
-          Qt.inputMethod.show();
-        });
-      }
 
       if (isCustom) {
         updateCustomUrlCombo();
         const currentUrl = customUrlCombo.editText.trim();
         const saved = urlHistory.find(e => e.url === currentUrl);
         serviceCrsTextField.text = saved ? saved.crs : (settings.service_crs || plugin.getActivePreset().crs);
+
+        Qt.callLater(() => {
+          customUrlCombo.forceActiveFocus();
+          Qt.inputMethod.show();
+        });
       } else {
         const preset = plugin.getPresetByName(endpointCombo.currentText);
         if (preset) {

--- a/main.qml
+++ b/main.qml
@@ -39,9 +39,9 @@ Item {
     category: "qfield-geomapfish-locator"
 
     property string service_endpoint: "GeoMapFish Demo"
-    property string service_url: ""
     property string service_crs: ""
-    property string service_endpoint_history: "[]"
+    property string service_custom_url: ""
+    property string service_custom_url_history: "[]"
   }
 
   function configure() {
@@ -55,7 +55,7 @@ Item {
     prefix: "gmf"
     locatorBridge: iface.findItemByObjectName('locatorBridge')
     parameters: {
-      "service_url": settings.service_url || plugin.getActivePreset().url,
+      "service_custom_url": settings.service_custom_url || plugin.getActivePreset().url,
       "service_crs": settings.service_crs || plugin.getActivePreset().crs
     }
     source: Qt.resolvedUrl('geomapfish.qml')
@@ -116,7 +116,7 @@ Item {
 
     function loadHistory() {
       try {
-        urlHistory = JSON.parse(settings.service_endpoint_history);
+        urlHistory = JSON.parse(settings.service_custom_url_history);
         if (!Array.isArray(urlHistory)) urlHistory = [];
       } catch (e) {
         urlHistory = [];
@@ -127,13 +127,13 @@ Item {
       urlHistory = urlHistory.filter(e => e.url !== url);
       urlHistory.unshift({ url: url, crs: crs });
       if (urlHistory.length > 10) urlHistory.length = 10;
-      settings.service_endpoint_history = JSON.stringify(urlHistory);
+      settings.service_custom_url_history = JSON.stringify(urlHistory);
     }
 
     function deleteFromHistory() {
       const url = customUrlCombo.editText.trim();
       urlHistory = urlHistory.filter(e => e.url !== url);
-      settings.service_endpoint_history = JSON.stringify(urlHistory);
+      settings.service_custom_url_history = JSON.stringify(urlHistory);
       updateCustomUrlCombo();
     }
 
@@ -173,10 +173,10 @@ Item {
       endpointItems.push(qsTr("Custom"));
       endpointCombo.model = endpointItems;
 
-      const isCustom = settings.service_url !== "";
+      const isCustom = settings.service_custom_url !== "";
       if (isCustom) {
         endpointCombo.currentIndex = endpointCombo.model.length - 1;
-        customUrlCombo.editText = settings.service_url;
+        customUrlCombo.editText = settings.service_custom_url;
       } else {
         const idx = endpointCombo.model.indexOf(settings.service_endpoint);
         endpointCombo.currentIndex = idx !== -1 ? idx : 0;
@@ -264,14 +264,14 @@ Item {
         }
 
         settings.service_endpoint = "Custom";
-        settings.service_url = url;
+        settings.service_custom_url = url;
         settings.service_crs = crs;
         saveToHistory(url, crs);
         mainWindow.displayToast(qsTr("Settings stored"));
       } else {
         const preset = plugin.getPresetByName(endpointCombo.currentText);
         settings.service_endpoint = endpointCombo.currentText;
-        settings.service_url = "";
+        settings.service_custom_url = "";
         settings.service_crs = crs;
 
         if (preset && crs !== preset.crs) {

--- a/main.qml
+++ b/main.qml
@@ -25,15 +25,18 @@ Item {
   Settings {
     id: settings
     category: "qfield-geomapfish-locator"
-    
+
     property string service_url: "https://geomapfish-demo-2-9.camptocamp.com/search"
     property string service_crs: "EPSG:2056"
+
+    // user pinned urls (json array)
+    property string pinned_service_urls: "[]"
   }
-  
+
   function configure() {
     settingsDialog.open();
   }
-  
+
   QFieldLocatorFilter {
     id: geoMapFishLocatorFilter
 
@@ -70,7 +73,7 @@ Item {
         )
         mapCanvas.mapSettings.setExtent(extent, true);
       }
-      
+
       locatorBridge.geometryHighlighter.qgsGeometry = result.userData;
       locatorBridge.geometryHighlighter.crs = CoordinateReferenceSystemUtils.fromDescription(parameters["service_crs"]);
     }
@@ -87,7 +90,7 @@ Item {
       }
     }
   }
-  
+
   Dialog {
     id: settingsDialog
     parent: mainWindow.contentItem
@@ -102,6 +105,134 @@ Item {
 
     width: mainWindow.width * 0.8
 
+    property string pendingServiceUrl: settings.service_url
+    property bool showCustomInput: false
+
+    ListModel { id: serviceUrlModel }
+
+    function normalizeUrl(url) {
+      return (url || "").trim()
+    }
+
+    function loadPinnedUrls() {
+      let arr = []
+      try {
+        arr = JSON.parse(settings.pinned_service_urls)
+      } catch (e) {
+        arr = []
+      }
+      if (!Array.isArray(arr)) {
+        arr = []
+      }
+
+      let clean = []
+      for (let i = 0; i < arr.length; i++) {
+        const normalUrl = normalizeUrl(arr[i])
+        if (!normalUrl) {
+          continue
+        }
+        if (clean.indexOf(normalUrl) === -1) {
+          clean.push(normalUrl)
+        }
+      }
+      return clean
+    }
+
+    function savePinnedUrls(arr) {
+      settings.pinned_service_urls = JSON.stringify(arr)
+    }
+
+    function isPinned(url) {
+      url = normalizeUrl(url)
+      if (!url) return false
+      return loadPinnedUrls().indexOf(url) !== -1
+    }
+
+    function rebuildModel() {
+      serviceUrlModel.clear()
+
+      const pinned = loadPinnedUrls()
+      for (let i = 0; i < pinned.length; i++) {
+        serviceUrlModel.append({ text: pinned[i], url: pinned[i], isCustom: false })
+      }
+
+      serviceUrlModel.append({ text: qsTr("Custom"), url: "__custom__", isCustom: true })
+    }
+
+    function setSelectionFromUrl(url) {
+      url = normalizeUrl(url)
+      settingsDialog.pendingServiceUrl = url
+
+      const pinned = loadPinnedUrls()
+      const idx = pinned.indexOf(url)
+
+      if (idx !== -1) {
+        // select pinned, hide custom input
+        serviceUrlCombo.currentIndex = idx
+        settingsDialog.showCustomInput = false
+        customServiceUrlTextField.text = url
+      } else {
+        // select custom, show input
+        serviceUrlCombo.currentIndex = serviceUrlModel.count - 1
+        settingsDialog.showCustomInput = true
+        customServiceUrlTextField.text = url
+      }
+    }
+
+    function pinUrl(url) {
+      url = normalizeUrl(url)
+      if (!url)
+      {
+        return
+      }
+
+      //avoid obvious invalid entries
+      if (url.indexOf("http://") !== 0 && url.indexOf("https://") !== 0) {
+        mainWindow.displayToast(qsTr("Please enter a valid http(s) URL"))
+        return
+      }
+
+      let pinned = loadPinnedUrls()
+      if (pinned.indexOf(url) === -1) {
+        pinned.unshift(url) // newest first
+        savePinnedUrls(pinned)
+      }
+
+      rebuildModel()
+      setSelectionFromUrl(url) // switches to pinned -> hides input
+    }
+
+    function unpinUrl(url) {
+      url = normalizeUrl(url)
+      if (!url)
+      {
+        return
+      }
+
+      let pinned = loadPinnedUrls()
+      const idx = pinned.indexOf(url)
+      if (idx !== -1) {
+        pinned.splice(idx, 1)
+        savePinnedUrls(pinned)
+      }
+
+      rebuildModel()
+      // after unpin -> go to Custom with the same url
+      serviceUrlCombo.currentIndex = serviceUrlModel.count - 1
+      settingsDialog.pendingServiceUrl = url
+      settingsDialog.showCustomInput = true
+      customServiceUrlTextField.text = url
+      customServiceUrlTextField.forceActiveFocus()
+    }
+
+    onOpened: {
+      settingsDialog.pendingServiceUrl = settings.service_url
+      serviceCrsTextField.text = settings.service_crs
+
+      rebuildModel()
+      setSelectionFromUrl(settingsDialog.pendingServiceUrl)
+    }
+
     ColumnLayout {
       width: parent.width
       spacing: 10
@@ -111,12 +242,130 @@ Item {
         text: qsTr("Service URL")
         font: Theme.defaultFont
       }
-      
-      TextField {
-        id: serviceUrlTextField
+
+      QfComboBox {
+        id: serviceUrlCombo
         Layout.fillWidth: true
         font: Theme.defaultFont
-        text: settings.service_url
+        model: serviceUrlModel
+        textRole: "text"
+
+        delegate: ItemDelegate {
+          width: ListView.view ? ListView.view.width : 200
+
+          contentItem: RowLayout {
+            width: parent.width
+            spacing: 10
+
+            Label {
+              Layout.fillWidth: true
+              text: model.text
+              font: Theme.defaultFont
+              elide: Text.ElideRight
+              verticalAlignment: Text.AlignVCenter
+            }
+
+            // pin icon on right only for pinned entries
+            Item {
+              visible: !model.isCustom
+              Layout.preferredWidth: 35
+              Layout.fillHeight: true
+              Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
+
+              QfToolButton {
+                width: parent.width
+                anchors.centerIn: parent
+                iconSource: Theme.getThemeVectorIcon("ic_pin_black_24dp")
+                iconColor: Theme.mainColor
+                bgcolor: "transparent"
+                enabled: false // click handled by MouseArea
+              }
+
+              MouseArea {
+                anchors.fill: parent
+                preventStealing: true
+
+                onClicked: function(mouse) {
+                  mouse.accepted = true
+                  settingsDialog.unpinUrl(model.url)
+                  mainWindow.displayToast(qsTr("Unpinned url "));
+                }
+              }
+            }
+          }
+
+          onClicked: {
+            serviceUrlCombo.currentIndex = index
+            serviceUrlCombo.popup.close()
+          }
+        }
+
+        onActivated: function(index) {
+          if (index < 0 || index >= serviceUrlModel.count)
+          {
+            return
+          }
+
+          const obj = serviceUrlModel.get(index)
+          if (!obj)
+          {
+            return
+          }
+
+          if (obj.url === "__custom__") {
+            settingsDialog.showCustomInput = true
+            customServiceUrlTextField.text = settingsDialog.pendingServiceUrl
+            customServiceUrlTextField.forceActiveFocus()
+          } else {
+            settingsDialog.pendingServiceUrl = obj.url
+            settingsDialog.showCustomInput = false
+          }
+        }
+      }
+
+      // custom input appears only if custom selected
+      RowLayout {
+        Layout.fillWidth: true
+        visible: settingsDialog.showCustomInput
+        spacing: 10
+
+        TextField {
+          id: customServiceUrlTextField
+          Layout.fillWidth: true
+          font: Theme.defaultFont
+          text: settingsDialog.pendingServiceUrl
+
+          onTextChanged: {
+            settingsDialog.pendingServiceUrl = settingsDialog.normalizeUrl(text)
+          }
+        }
+
+        // Pin icon beside custom field
+        Item {
+          Layout.preferredWidth: 45
+          Layout.preferredHeight: customServiceUrlTextField.implicitHeight
+
+          QfToolButton {
+            width: parent.width
+            anchors.centerIn: parent
+            iconSource: Theme.getThemeVectorIcon("ic_pin_black_24dp")
+            iconColor: settingsDialog.isPinned(settingsDialog.pendingServiceUrl) ? Theme.mainTextDisabledColor : Theme.mainColor
+            bgcolor: "transparent"
+            enabled: false
+          }
+
+          MouseArea {
+            anchors.fill: parent
+            onClicked: {
+              if (settingsDialog.isPinned(settingsDialog.pendingServiceUrl)) {
+                mainWindow.displayToast(qsTr("This URL is already pinned"))
+                return
+              }
+              settingsDialog.pinUrl(settingsDialog.pendingServiceUrl)
+              mainWindow.displayToast(qsTr("Pinned URL"))
+            }
+          }
+        }
       }
 
       Label {
@@ -124,7 +373,7 @@ Item {
         text: qsTr("Service CRS")
         font: Theme.defaultFont
       }
-      
+
       TextField {
         id: serviceCrsTextField
         Layout.fillWidth: true
@@ -134,7 +383,7 @@ Item {
     }
 
     onAccepted: {
-      settings.service_url = serviceUrlTextField.text;
+      settings.service_url = settingsDialog.pendingServiceUrl;
       settings.service_crs = serviceCrsTextField.text;
       mainWindow.displayToast(qsTr("Settings stored"));
     }


### PR DESCRIPTION
Previously the GeoMapFish plugin required users to manually type the Service URL inside the settings dialog each time.
This PR replaces that flow with a safer and more reusable UI

What changed

- Replaced the Service URL TextField with a combo box:
    - shows default URL options
    - includes a Custom option for entering your own URL
- Added support to pin multiple custom URLs as presets
- Added unpin support to remove unused URLs
- Pinned URLs are stored in Settings (pinned_service_urls) and loaded automatically next time

Try plugin with this url: 
[qfield-geomapfish-locator-1.zip](https://github.com/user-attachments/files/24656521/qfield-geomapfish-locator-1.zip)


_______
Note: You get an option to not pin the url if it is not recurively use, ex. demo or test url, which you only use once or twice.
pin helps you keep the urls as preset, and you can see the list and unpin if not going to be in use.

Demo:

https://github.com/user-attachments/assets/bf2f1e90-7fda-4e73-96de-58c8459fc773